### PR TITLE
Fix jshint require.

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,8 +7,9 @@ module.exports = function (paths) {
 				this.timeout(30000);
 				var cwd = process.cwd();
 				process.chdir(path.resolve(p));
-				delete require.cache[require.resolve('./node_modules/jshint/src/cli.js')];
-				var jsHint = require('./node_modules/jshint/src/cli.js');
+				var jsHintCliPath = path.resolve(path.dirname(require.resolve('jshint')), 'cli.js');
+				delete require.cache[jsHintCliPath];
+				var jsHint = require(jsHintCliPath);
 				var error = new Error('');
 				error.message = '';
 				error.stack = '';


### PR DESCRIPTION
Fixed this crash:

```
1) jshint should pass for working directory:
     Error: Cannot find module './node_modules/jshint/src/cli.js'
      at Function.Module._resolveFilename (module.js:338:15)
      at Function.require.resolve (module.js:384:19)
      at Context.<anonymous> (/Users/mickeyreiss/personal_code/Yaniv-Core/node_modules/mocha-jshint/index.js:10:34)
      at Test.Runnable.run (/Users/mickeyreiss/personal_code/Yaniv-Core/node_modules/mocha/lib/runnable.js:211:32)
      at Runner.runTest (/Users/mickeyreiss/personal_code/Yaniv-Core/node_modules/mocha/lib/runner.js:358:10)
      at /Users/mickeyreiss/personal_code/Yaniv-Core/node_modules/mocha/lib/runner.js:404:12
      at next (/Users/mickeyreiss/personal_code/Yaniv-Core/node_modules/mocha/lib/runner.js:284:14)
      at /Users/mickeyreiss/personal_code/Yaniv-Core/node_modules/mocha/lib/runner.js:293:7
      at next (/Users/mickeyreiss/personal_code/Yaniv-Core/node_modules/mocha/lib/runner.js:237:23)
      at Object._onImmediate (/Users/mickeyreiss/personal_code/Yaniv-Core/node_modules/mocha/lib/runner.js:261:5)
      at processImmediate [as _immediateCallback] (timers.js:330:15)
```
