### PR TITLE
exec options to e.g. fix maxBuffer errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,10 @@ If you are using git as version control you can do the following in your test:
 require('mocha-jshint')({
 	git: {
 		modified: true,
-		commits: 2
+		commits: 2,
+		exec: {
+			maxBuffer: 20*1024*1024
+		}
 	}
 });
 ```

--- a/git.js
+++ b/git.js
@@ -11,7 +11,7 @@ module.exports = function (options, cb) {
 		cb(new Error('git options need to have either options.modified:true or have options.commits>0'));
 	}
 	if (options.masterDiff) {
-		return exec('git rev-parse --abbrev-ref HEAD', getFilesChangesInCurrentBranch);
+		return exec('git rev-parse --abbrev-ref HEAD', options.exec, getFilesChangesInCurrentBranch);
 	}
 	return compareLatestCommits();
 
@@ -27,12 +27,12 @@ module.exports = function (options, cb) {
 		if (options.modified) {
 			command += ' && git diff --name-only HEAD';
 		}
-		return exec(command, returnFiles);
+		return exec(command, options.exec, returnFiles);
 	}
 
 	function compareLatestCommits() {
 		var maxCount = (options.commits || 0) + 1;
-		return exec(format('git log --pretty=format:%h --max-count=%d', maxCount), findSHA);
+		return exec(format('git log --pretty=format:%h --max-count=%d', maxCount), options.exec, findSHA);
 	}
 
 	function findSHA(err, stdout) {
@@ -50,7 +50,7 @@ module.exports = function (options, cb) {
 		if (!command) {
 			return cb(null, []);
 		}
-		return exec(command, returnFiles);
+		return exec(command, options.exec, returnFiles);
 	}
 
 	function returnFiles(err, stdout) {

--- a/test/jshint.exec.spec.js
+++ b/test/jshint.exec.spec.js
@@ -1,0 +1,6 @@
+require('../index.js')({
+	exec: {
+		modified: true,
+		maxBuffer: 20*1024*1024
+	}
+});


### PR DESCRIPTION
Default maxBuffer for exec calls is 200*1024 which may be inadequate
for many git calls resulting in error

    Error: stdout maxBuffer exceeded.

Added option to supply the exec options and thus be able to override
the default maxBuffer option.